### PR TITLE
upgrade pybind11

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -19,7 +19,7 @@ jobs:
         platform: [ manylinux2014_x86_64 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Build the Linux wheels
@@ -28,7 +28,7 @@ jobs:
           # cleanup for custom runner
           sudo chown -R $(whoami):$(whoami) .
       - name: Archive wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # we strip the version number from the artifact name
           name: pytlsd-${{ matrix.platform }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-12, windows-2022]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pybind11"]
 	path = pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "lib/pybind11"]
+[submodule "pybind11"]
 	path = pybind11
-	url = https://github.com/pybind/pybind11
-	branch = stable
+	url = git@github.com:pybind/pybind11.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 files = "setup.py"
-python_version = "3.9"
+python_version = "3.7"
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 files = "setup.py"
-python_version = "3.7"
+python_version = "3.9"
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
The upgrade of pybind11 becomes necessary to avoid cmake error. 